### PR TITLE
set the name label explicitly to avoid high churn

### DIFF
--- a/K6/clients/dialogporten/serviceowner/serviceowner.js
+++ b/K6/clients/dialogporten/serviceowner/serviceowner.js
@@ -208,7 +208,10 @@ class ServiceOwnerApiClient {
             if (value) url.searchParams.append(key, value);
         }
 
-        let tags = { endpoint: this.FULL_PATH + "/dialogs" };
+        let tags = {
+            endpoint: this.FULL_PATH + "/dialogs",
+            name: this.FULL_PATH + "/dialogs"
+        };
         if (labels != null) {
             tags = { ...labels, ...tags };
         }


### PR DESCRIPTION
`https://platform.at23.altinn.cloud/dialogporten/api/v1/serviceowner/dialogs?endsuserid=urn%3aaltinn%3aperson%3aidentifier-no%3a01846698058&serviceresources=urn%3aaltinn%3aresource%3ak6-instancedelegation-test`
Will collapse into
`https://platform.at23.altinn.cloud/dialogporten/api/v1/serviceowner/dialogs`