### PR TITLE
Call CreateScopeString instead of indexing it

### DIFF
--- a/K6/api/tests/sanity-checks/token-generators.js
+++ b/K6/api/tests/sanity-checks/token-generators.js
@@ -39,11 +39,11 @@ export function setup() {
 export default async function () {
     const ORG = "ttd";
     // Maskinporten takes the requested scopes space-separated in the grant.
-    const scopes = CreateScopeString[
+    const scopes = CreateScopeString([
         AltinnScopes.ACCESSMANAGEMENT.ENDUSER.REQUESTS.WRITE,
         AltinnScopes.CONSENTREQUESTS.READ,
         AltinnScopes.CONSENTREQUESTS.WRITE
-    ];
+    ]);
 
     // Every generator is set up the same way. ensureToken is awaited outside the
     // groups, since group() takes a synchronous callback.


### PR DESCRIPTION
The token generator sanity check built its scope string with square brackets, so JS evaluated the three scopes as a comma expression and looked the last one up as a property on the function. That is `undefined`, so the `scopes` query parameter was left out and `GetEnterpriseToken` answered 400 Bad Request. The platform token in the same test passed, since it takes no scopes.

Verified against the token generator directly: the same request is 400 without scopes and 200 with them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)